### PR TITLE
Fix Showcase Crash

### DIFF
--- a/common/src/main/kotlin/dev/chasem/cobblemonextras/CobblemonExtras.kt
+++ b/common/src/main/kotlin/dev/chasem/cobblemonextras/CobblemonExtras.kt
@@ -154,7 +154,10 @@ object CobblemonExtras {
 
         PokeShoutAll().register(dispatcher)
         EmptyBox().register(dispatcher)
-        Showcase().register(dispatcher)
+
+        if (config.showcase.isShowcaseEnabled) {
+            Showcase().register(dispatcher)
+        }
         ItemShout().register(dispatcher)
         PokeOdds().register(dispatcher)
         PokeKill().register(dispatcher)


### PR DESCRIPTION
Fixes the long-standing bug where players can freely crash the server via `/showcase` by preventing the command from registering if showcase is disabled.