### PR TITLE
Don't shade kotlinx-coroutines-core in Fabric .jar

### DIFF
--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -33,10 +33,7 @@ dependencies {
     "developmentFabric"(project(":common", configuration = "namedElements"))
 
     implementation("org.apache.httpcomponents:httpclient:4.5.13")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
     shadowCommon("org.apache.httpcomponents:httpclient:4.5.13")
-    shadowCommon("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
-
 
     modImplementation("com.cobblemon:fabric:${property("cobblemon_version")}") { isTransitive = false }
     shadowCommon(project(":common", configuration = "transformProductionFabric"))


### PR DESCRIPTION
Fabric Language Kotlin already provides coroutines. Shading them into the .jar creates compatibility issues with other mods that attempt to use methods from a newer Kotlin version if the server loads an older one from Cobblemon Extras. For example, if a mod migrates from `kotlinx.datetime.Clock` to `kotlin.time.Clock`, that mod can fail to call the new `PlatformImplementations.getSystemClock()`, which doesn't exist in the `PlatformImplementations` bundled with Cobblemon Extras.